### PR TITLE
Dockerfiles: set `DEBIAN_FRONTEND=noninteractive` for `apt-get`.

### DIFF
--- a/docker/Dockerfile-riak-2.x
+++ b/docker/Dockerfile-riak-2.x
@@ -3,6 +3,7 @@ ARG RIAK_VSN
 
 EXPOSE 8087 8098 9080
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y git wget g++ libpam0g-dev
 
 ADD riak-${RIAK_VSN} /usr/src/S
@@ -16,6 +17,7 @@ ARG RIAK_VSN
 ARG RCS_BACKEND_1
 ARG RCS_BACKEND_2
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl1.1 logrotate sudo
 
 COPY --from=compile-image /usr/src/S/rel/riak /opt/riak

--- a/docker/Dockerfile-riak-3.0.x
+++ b/docker/Dockerfile-riak-3.0.x
@@ -3,6 +3,7 @@ ARG RIAK_VSN
 
 EXPOSE 8087 8098 9080
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libssl-dev libpam0g-dev cmake
 
 ADD riak-${RIAK_VSN} /usr/src/S
@@ -15,6 +16,7 @@ ARG RIAK_VSN
 ARG RCS_BACKEND_1
 ARG RCS_BACKEND_2
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl1.1
 
 COPY --from=compile-image /usr/src/S/rel/riak /opt/riak

--- a/docker/Dockerfile-riak-3.2.x
+++ b/docker/Dockerfile-riak-3.2.x
@@ -3,6 +3,7 @@ ARG RIAK_VSN
 
 EXPOSE 8087 8098 9080
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libssl-dev libpam0g-dev cmake
 
 ADD riak-${RIAK_VSN} /usr/src/S
@@ -15,6 +16,7 @@ ARG RIAK_VSN
 ARG RCS_BACKEND_1
 ARG RCS_BACKEND_2
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl1.1
 
 COPY --from=compile-image /usr/src/S/rel/riak /opt/riak

--- a/docker/Dockerfile-riak_cs-2.x
+++ b/docker/Dockerfile-riak_cs-2.x
@@ -3,6 +3,7 @@ ARG RCS_VSN
 
 EXPOSE 8080 8000
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && install -y git wget g++ libpam0g-dev
 
 ADD riak_cs-${RCS_VSN} /usr/src/S

--- a/docker/Dockerfile-riak_cs-3.0.x
+++ b/docker/Dockerfile-riak_cs-3.0.x
@@ -13,6 +13,7 @@ RUN make rel
 
 FROM debian:buster AS runtime-image
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl1.1
 
 COPY --from=compile-image /usr/src/S/rel/riak-cs /opt/riak-cs

--- a/docker/Dockerfile-riak_cs-3.1.x
+++ b/docker/Dockerfile-riak_cs-3.1.x
@@ -5,7 +5,8 @@ ARG RCS_VSN
 
 EXPOSE 8080 8000 8085
 
-RUN apt-get -y install libssl-dev
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install libssl-dev
 
 ADD riak_cs-${RCS_VSN} /usr/src/S
 WORKDIR /usr/src/S
@@ -14,8 +15,8 @@ RUN make rel
 
 FROM debian:bullseye AS runtime-image
 
-RUN apt-get update
-RUN apt-get -y install libssl1.1
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install libssl1.1
 
 COPY --from=compile-image /usr/src/S/rel/riak-cs /opt/riak-cs
 ENV RCS_PATH=/opt/riak-cs

--- a/docker/Dockerfile-riak_cs-3.2.x
+++ b/docker/Dockerfile-riak_cs-3.2.x
@@ -5,6 +5,7 @@ ARG RCS_VSN
 
 EXPOSE 8080 8000 8085
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl-dev
 
 ADD riak_cs-${RCS_VSN} /usr/src/S
@@ -14,8 +15,8 @@ RUN make rel
 
 FROM debian:bullseye AS runtime-image
 
-RUN apt-get update
-RUN apt-get -y install libssl1.1 python3-boto3 python3-httplib2
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install libssl1.1 python3-boto3 python3-httplib2
 
 COPY --from=compile-image /usr/src/S/rel/riak-cs /opt/riak-cs
 ENV RCS_PATH=/opt/riak-cs

--- a/docker/Dockerfile-riak_cs_control-3.x
+++ b/docker/Dockerfile-riak_cs_control-3.x
@@ -9,6 +9,7 @@ ARG RCSC_VSN=3.0.0 \
 FROM erlang:25 AS compile-image
 ARG RCSC_VSN
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libssl-dev
 
 EXPOSE 8090
@@ -35,6 +36,7 @@ ENV CS_HOST=${CS_HOST} \
     LOG_DIR=/opt/riak_cs_control/log \
     LOGGER_LEVEL=info
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl1.1
 
 COPY --from=compile-image /usr/src/S/_build/rel/rel/riak_cs_control /opt/riak_cs_control

--- a/docker/Dockerfile-stanchion-2.x
+++ b/docker/Dockerfile-stanchion-2.x
@@ -3,6 +3,7 @@ ARG STANCHION_VSN
 
 EXPOSE 8085
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && install -y git wget g++ libpam0g-dev
 
 ADD stanchion-${STANCHION_VSN} /usr/src/S

--- a/docker/Dockerfile-stanchion-3.x
+++ b/docker/Dockerfile-stanchion-3.x
@@ -13,6 +13,7 @@ RUN make rel
 
 FROM debian:buster AS runtime-image
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install libssl1.1
 
 COPY --from=compile-image /usr/src/S/rel/stanchion /opt/stanchion


### PR DESCRIPTION
Setting it via `ARG` makes it available during all the build (eg. the `dpkg` invocation).
Also, using `ARG`, the variable is not persisted at container run time (i.e. set only during build).

Added a couple missing `apt-get update`s here and there.